### PR TITLE
design: 하트 컴포넌트 svg로 변경 / 블랙 옵션 추가

### DIFF
--- a/app/src/components/ui/HeartItem.tsx
+++ b/app/src/components/ui/HeartItem.tsx
@@ -1,14 +1,56 @@
 "use client";
-import Image from "next/image";
 import { useState } from "react";
+
+interface HeartProps {
+  size?: number;
+}
+
+const FilledHeart = ({ size = 20 }: HeartProps) => (
+  <svg width={size} height={size * 0.9} viewBox="0 0 20 18" fill="none">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M9.81874 2.72467C8.01936 0.646974 5.01873 0.0880758 2.76417 1.99063C0.509631 3.89318 0.192224 7.07412 1.96273 9.32436L9.81874 16.8262L17.6748 9.32436C19.4454 7.07412 19.1667 3.87317 16.8734 1.99063C14.58 0.108095 11.6182 0.646974 9.81874 2.72467Z"
+      fill="#FF6155"
+      stroke="#FF6155"
+      strokeWidth="1.64966"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const EmptyHeart = ({
+  color,
+  size = 20,
+}: {
+  color: "white" | "black";
+  size?: number;
+}) => (
+  <svg width={size} height={size * 0.9} viewBox="0 0 20 18" fill="none">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M9.81874 2.72467C8.01936 0.646974 5.01873 0.0880757 2.76417 1.99063C0.509631 3.89318 0.192224 7.07412 1.96273 9.32436L9.81874 16.8262L17.6748 9.32436C19.4454 7.07412 19.1667 3.87317 16.8734 1.99063C14.58 0.108095 11.6182 0.646974 9.81874 2.72467Z"
+      stroke={color}
+      strokeWidth="1.64966"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 interface WishButtonProps {
   initialWished?: boolean;
+  lineColor?: "black" | "white";
+  size?: number;
   className?: string;
 }
 
 export default function HeartItem({
   initialWished = false,
+  lineColor = "black",
+  size = 20,
   className = "",
 }: WishButtonProps) {
   const [isWished, setIsWished] = useState(initialWished);
@@ -18,12 +60,11 @@ export default function HeartItem({
       onClick={() => setIsWished(!isWished)}
       className={`p-2 hover:scale-110 transition-transform ${className}`}
     >
-      <Image
-        src={isWished ? "/filledHeart.png" : "/emptyHeart.png"}
-        width={27}
-        height={27}
-        alt="찜"
-      />
+      {isWished ? (
+        <FilledHeart size={size} />
+      ) : (
+        <EmptyHeart color={lineColor} size={size} />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/heart-component-#이슈번호

### 이슈
#16

### 작업 사항
찜 기능을 위한 하트 아이콘 컴포넌트 수정

**Heart 컴포넌트**
- 반응형 크기 조절 지원 (props로 size 제어)
- 빈 상태일시 블랙 옵션 추가
- 아이콘 소스 png -> svg로 변경

**적용 위치**
- 반찬 카드 컴포넌트
- 반찬 상세 페이지

### 전달 사항
하트 컴포넌트 옵션 사용 방법
```typescript
// 기본 사용 (20px)
<HeartItem />

// 24px로 크게
<HeartItem size={24} />

// 16px로 작게
<HeartItem size={16} />

// 하얀 라인 + 큰 사이즈
<HeartItem lineColor="white" size={32} />

// 처음부터 찜 상태 + 작은 사이즈
<HeartItem initialWished={true} size={18} />

// 모든 옵션 조합
<HeartItem 
  initialWished={false}
  lineColor="white"
  size={28}
  className="absolute top-4 right-4"
/>
```