### PR TITLE
fix: 반찬 관리 페이지 뒤로가기 버그 해결

### DIFF
--- a/app/mypage/banchan/[id]/edit/EditBanchanClient.tsx
+++ b/app/mypage/banchan/[id]/edit/EditBanchanClient.tsx
@@ -197,13 +197,13 @@ export default function EditBanchanClient({ id }: EditBanchanClientProps) {
 
   const handleModalConfirm = () => {
     setShowModal(false);
-    router.push('/mypage/banchan');
+    router.replace('/mypage/banchan');
   };
 
   const handleDelete = async () => {
     try {
       await deleteBanchan(Number(id));
-      router.push('/mypage/banchan');
+      router.replace('/mypage/banchan');
     } catch {
       alert('반찬 삭제에 실패했습니다. 다시 시도해주세요.');
     }

--- a/app/mypage/banchan/new/NewBanchanClient.tsx
+++ b/app/mypage/banchan/new/NewBanchanClient.tsx
@@ -173,7 +173,7 @@ export default function NewBanchanClient() {
   // 모달 확인 버튼
   const handleModalConfirm = () => {
     setShowModal(false);
-    router.push('/mypage/banchan');
+    router.replace('/mypage/banchan');
   };
 
   return (


### PR DESCRIPTION
### PR 타입
- [X] 버그 해결

### 반영 브랜치

feat/sellers

### 이슈

[#이슈 번호](이슈 링크)

#121

### 작업 사항
- 뒤로가기 무한 루프 해결
- router.push()를 router.replace()로 대체하여 등록/수정페이지가 히스토리에 남지 않게 수정
